### PR TITLE
Added 'main' annotation to project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,4 +6,5 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojars.cognesence/breadth-search "0.9.0"]
                  [org.clojars.cognesence/matcher "1.0.1"]
-                 [org.clojars.cognesence/ops-search "1.0.1"]])
+                 [org.clojars.cognesence/ops-search "1.0.1"]]
+  :main matcher-starter.core)


### PR DESCRIPTION
Added 'main' annotation to project.clj that imports 'matcher-starter.core' namespace automatically.